### PR TITLE
Fix build with MSVC 2013 Express in UE4 Editor 4.1

### DIFF
--- a/Source/MercurialSourceControl/Private/MercurialSourceControlModule.cpp
+++ b/Source/MercurialSourceControl/Private/MercurialSourceControlModule.cpp
@@ -31,10 +31,10 @@
 
 namespace MercurialSourceControl {
 
-namespace 
-{
-	const char* SourceControl = "SourceControl";
+extern const char* SourceControl = "SourceControl";
 
+namespace
+{
 	template<typename T>
 	FWorkerRef CreateWorker()
 	{

--- a/Source/MercurialSourceControl/Private/MercurialSourceControlProvider.cpp
+++ b/Source/MercurialSourceControl/Private/MercurialSourceControlProvider.cpp
@@ -37,7 +37,7 @@ namespace MercurialSourceControl {
 // for LOCTEXT()
 #define LOCTEXT_NAMESPACE "MercurialSourceControl"
 
-static const char* SourceControl = "SourceControl";
+extern const char* SourceControl /* = "SourceControl" */; // initialized in Module
 static FName ProviderName("Mercurial");
 
 void FProvider::Init(bool bForceConnection)


### PR DESCRIPTION
- I am building the plugin directly inside the UE4 Editor sources,
  not sure if its why I had this "double definition" issue and not you.
