### PR TITLE
Fix linux/clang build with UE 4.5 github sources

### DIFF
--- a/Source/MercurialSourceControl/Private/MercurialSourceControlClient.cpp
+++ b/Source/MercurialSourceControl/Private/MercurialSourceControlClient.cpp
@@ -89,7 +89,7 @@ bool FClient::FindExecutable(FString& OutFilename)
 {
 	OutFilename.Empty();
 
-#ifdef PLATFORM_WINDOWS
+#if PLATFORM_WINDOWS
 	// look for the hg.exe that's shipped with TortoiseHg
 	const TCHAR* SubKey = TEXT("Software\\TortoiseHg");
 	const TCHAR* ValueName = TEXT("");

--- a/Source/MercurialSourceControl/Private/MercurialSourceControlProvider.cpp
+++ b/Source/MercurialSourceControl/Private/MercurialSourceControlProvider.cpp
@@ -294,10 +294,12 @@ void FProvider::Tick()
 	}
 }
 
+#if SOURCE_CONTROL_WITH_SLATE
 TSharedRef<class SWidget> FProvider::MakeSettingsWidget() const
 {
 	return SNew(SProviderSettingsWidget);
 }
+#endif
 
 void FProvider::RegisterWorkerCreator(
 	const FName& InOperationName, const FCreateWorkerDelegate& InDelegate

--- a/Source/MercurialSourceControl/Private/MercurialSourceControlProvider.h
+++ b/Source/MercurialSourceControl/Private/MercurialSourceControlProvider.h
@@ -93,7 +93,9 @@ public:
 
 	virtual bool UsesLocalReadOnlyState() const override;
 	virtual void Tick() override;
+#if SOURCE_CONTROL_WITH_SLATE
 	virtual TSharedRef<class SWidget> MakeSettingsWidget() const override;
+#endif
 
 public:
 	FProvider() : ProviderName("Mercurial") {}


### PR DESCRIPTION
While testing my own Git plugin, here is my small contribution to you.

First of all, it compiles flawlessly with UE4.5 on MSVC 2013 under Windows 7.
Then, with those fixes it also compiles with UE4.5 GitHub sources on clang 3.3 under Ubuntu 14.04 64 bits

 - #if PLAFTORM_WINDOWS instead of #ifdef PLAFTORM_WINDOWS
 - #if SOURCE_CONTROL_WITH_SLATE arround MakeSettingsWidget() like in all other source control providers