### PR TITLE
Update Code to work with UE 4.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 Intermediate/
+Binaries/

--- a/Source/MercurialSourceControl/Private/MercurialSourceControlClient.cpp
+++ b/Source/MercurialSourceControl/Private/MercurialSourceControlClient.cpp
@@ -190,7 +190,7 @@ bool FClient::GetFileStates(
 	if (RunCommand(TEXT("status"), Options, InWorkingDirectory, RelativeFiles, false, Output, OutErrors))
 	{
 		TArray<FString> Lines;
-		Output.ParseIntoArray(&Lines, TEXT("\n"), true);
+		Output.ParseIntoArray(Lines, TEXT("\n"), true);
 		for (const auto& Line : Lines)
 		{
 			// each line consists of a one character status code followed by a filename, 
@@ -517,7 +517,7 @@ bool FClient::RunCommand(
 	);
 
 	TArray<FString> ErrorMessages;
-	if (StdError.ParseIntoArray(&ErrorMessages, TEXT("\n"), true) > 0)
+	if (StdError.ParseIntoArray(ErrorMessages, TEXT("\n"), true) > 0)
 	{
 		OutErrorMessages.Append(ErrorMessages);
 	}
@@ -655,7 +655,7 @@ FDateTime FClient::Rfc3339DateToDateTime(const FString& InDateString)
 	Buffer.ReplaceInline(TEXT(":"), Space);
 
 	TArray<FString> Segments;
-	Buffer.ParseIntoArray(&Segments, Space, true);
+	Buffer.ParseIntoArray(Segments, Space, true);
 
 	int32 Year = FMath::Clamp((Segments.Num() > 0) ? FCString::Atoi(*Segments[0]) : 0, 0, 9999);
 	int32 Month = FMath::Clamp((Segments.Num() > 1) ? FCString::Atoi(*Segments[1]) : 0, 1, 12);

--- a/Source/MercurialSourceControl/Private/MercurialSourceControlCommand.h
+++ b/Source/MercurialSourceControl/Private/MercurialSourceControlCommand.h
@@ -34,7 +34,7 @@ typedef TSharedRef<class ISourceControlOperation, ESPMode::ThreadSafe> FSourceCo
  * Executes a Mercurial command, the execution may be done on a worker thread.
  * The hard work is delegated to an IMercurialSourceControlWorker object. 
  */
-class FCommand : public FQueuedWork
+class FCommand : public IQueuedWork
 {
 public:
 	FCommand(

--- a/Source/MercurialSourceControl/Private/MercurialSourceControlFileState.h
+++ b/Source/MercurialSourceControl/Private/MercurialSourceControlFileState.h
@@ -76,6 +76,12 @@ public:
 		History = InFileRevisions;
 	}
 
+	// kill ambiguous error message:
+	TSharedRef< FFileState, ESPMode::ThreadSafe> AsShared()
+	{
+		return TSharedFromThis<FFileState, ESPMode::ThreadSafe>::AsShared();
+	}
+
 public:
 	// ISourceControlState methods
 

--- a/Source/MercurialSourceControl/Private/MercurialSourceControlProvider.cpp
+++ b/Source/MercurialSourceControl/Private/MercurialSourceControlProvider.cpp
@@ -501,6 +501,21 @@ void FProvider::PrepareFilenamesForAddCommand(
 	}
 }
 
+TArray<FSourceControlStateRef> FProvider::GetCachedStateByPredicate(
+	const TFunctionRef<bool(const FSourceControlStateRef&)>& Predicate) const
+{
+	TArray<FSourceControlStateRef> Reval;
+	for(auto Iter = FileStateMap.CreateConstIterator(); Iter; ++Iter)
+	{
+		auto FileState = Iter.Value();
+		if(Predicate(FileState))
+		{
+			Reval.Add(FileState);
+		}
+	}
+	return Reval;
+}
+
 #undef LOCTEXT_NAMESPACE
 
 } // namespace namespace MercurialSourceControl

--- a/Source/MercurialSourceControl/Private/MercurialSourceControlProvider.h
+++ b/Source/MercurialSourceControl/Private/MercurialSourceControlProvider.h
@@ -68,11 +68,10 @@ public:
 		EStateCacheUsage::Type InStateCacheUsage
 	) override;
 
-	// The following two methods have been DEPRECATED and replaced by 
-	// RegisterSourceControlStateChanged_Handle() and UnregisterSourceControlStateChanged_Handle().
-	virtual void RegisterSourceControlStateChanged(const FSourceControlStateChanged::FDelegate& SourceControlStateChanged) override {}
-	virtual void UnregisterSourceControlStateChanged(const FSourceControlStateChanged::FDelegate& SourceControlStateChanged) override {}
+	virtual TArray<FSourceControlStateRef> GetCachedStateByPredicate(
+		const TFunctionRef<bool(const FSourceControlStateRef&)>& Predicate) const;
 
+	
 	virtual FDelegateHandle RegisterSourceControlStateChanged_Handle(
 		const FSourceControlStateChanged::FDelegate& SourceControlStateChanged
 	) override;


### PR DESCRIPTION
Hi,

I updated your plugin to compile against 4.9. There are three deprecated warnings left. But with those changes it can be loaded and use in 4.9.

I also changed the ignore file such that git submodules commands work without complaining about dirty state of the directory.

Looking forward to hear from you.
Greetings
Tim