### PR TITLE
Fixed build errors for UE 4.22

### DIFF
--- a/MercurialSourceControl.uplugin
+++ b/MercurialSourceControl.uplugin
@@ -8,7 +8,7 @@
 	"CreatedByURL" : "https://github.com/enlight/ue4-hg-plugin",
 	"Description" : "Allows the Editor to interact with the Mercurial distributed version control system. Supports basic add, remove, revert, commit operations, provides access to asset history, and enables built-in visual diffing of Blueprints.",
 	"Category" : "Editor.Source Control",
-	"EngineVersion" : "4.21.2",
+	"EngineVersion" : "4.22.0",
 	
     "Modules" :
 	[

--- a/Source/MercurialSourceControl/Private/MercurialSourceControlCommand.h
+++ b/Source/MercurialSourceControl/Private/MercurialSourceControlCommand.h
@@ -142,14 +142,14 @@ private:
 	/** Absolute path to the current content directory. */
 	FString ContentDirectory;
 
-	/** Will be set to true if the operation is performed successfully. */
-	bool bCommandSuccessful;
-
 	/** Executed after the operation completes. */
 	FSourceControlOperationComplete OperationCompleteDelegate;
 
 	/** Has the operation been completed? */
 	volatile int32 bExecuteProcessed;
+
+	/** Will be set to true if the operation is performed successfully. */
+	bool bCommandSuccessful;
 
 	/** Is this operation being performed synchronously or asynchronously? */
 	EConcurrency::Type Concurrency;


### PR DESCRIPTION
A class member was declared in other order than it was initialized in the constructor that caused an error.